### PR TITLE
Fix iconPickerUrl detection with URL parameters

### DIFF
--- a/assets/js/universal-icon-picker.js
+++ b/assets/js/universal-icon-picker.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /*jshint esversion: 8 */
-const iconPickerUrl = document.currentScript.src.replace(/js\/([a-z\.-]+)$/gm, '');
+const scriptUrl = new URL(document.currentScript.src);
+const iconPickerUrl = scriptUrl.origin + scriptUrl.pathname.substring(0, scriptUrl.pathname.lastIndexOf('/js') + 1);
 const loadedDependencies = [];
 
 (function (root, factory) {


### PR DESCRIPTION
This pull request addresses an issue with the detection of iconPickerUrl when the URL contains parameters, such as /universal-icon-picker.js?ver=3.0.0. The fix ensures that the iconPickerUrl is correctly identified regardless of the presence of URL parameters, improving the reliability of the Universal Icon Picker.